### PR TITLE
Warn instead of error while building schema

### DIFF
--- a/gatsbyNodeHelper/index.js
+++ b/gatsbyNodeHelper/index.js
@@ -43,11 +43,14 @@ const createPageDataStruct = ({ chamber, legislatorId }) => {
     }
     //sponsorship
     const progMassSponsoredBills = legislationData[year].sponsoredBills
-    try {
-      const legislatorSponsorshipEntry = getLegislatorSponsorshipEntry({
-        year,
-        legislatorId,
-      })
+    const legislatorSponsorshipEntry = getLegislatorSponsorshipEntry({
+      year,
+      legislatorId,
+    })
+    if (legislatorSponsorshipEntry === undefined) {
+      termData.sponsorship = []
+      console.warn(`${pageData.legislator.name} didn't have sponsorship data available for ${year}`)
+    } else {
       const legislatorSponsorship = legislatorSponsorshipEntry.data
 
       termData.sponsorship = Object.keys(legislatorSponsorship).map(billNum => {
@@ -67,23 +70,19 @@ const createPageDataStruct = ({ chamber, legislatorId }) => {
           yourLegislator: legislatorSponsorship[billNum],
         }
       })
-    } catch (e) {
-      termData.sponsorship = []
-      console.error(
-        `${
-          pageData.legislator.name
-        } didn't have sponsorship data available for ${year}: ${e.toString()}`
-      )
     }
 
     // votes
     if (legislationData[year][`${chamber}Votes`]) {
-      try {
-        const legislatorVotesEntry = getLegislatorVotesEntry({
-          year,
-          chamber,
-          legislatorId,
-        })
+      const legislatorVotesEntry = getLegislatorVotesEntry({
+        year,
+        chamber,
+        legislatorId,
+      })
+      if (legislatorVotesEntry === undefined) {
+        termData.votes = []
+        console.warn(`${pageData.legislator.name} didn't have vote data available for ${year}`)
+      } else {
         const legislatorVotes = legislatorVotesEntry.data
 
         termData.votes = Object.keys(legislatorVotes).map(rollCallNumber => {
@@ -92,13 +91,6 @@ const createPageDataStruct = ({ chamber, legislatorId }) => {
             yourLegislator: legislatorVotes[rollCallNumber],
           }
         })
-      } catch (e) {
-        termData.votes = []
-        console.error(
-          `${
-            pageData.legislator.name
-          } didn't have vote data available for ${year}: ${e.toString()}`
-        )
       }
     }
     return termData


### PR DESCRIPTION
This makes the output much nicer and easier to read when starting up the server.

Sample output before:
![Screen Shot 2021-05-15 at 8 41 09 PM](https://user-images.githubusercontent.com/6565058/118381915-e6c44180-b5bd-11eb-8834-8636fd872a9b.png)


Same sample output after:
![Screen Shot 2021-05-15 at 8 38 39 PM](https://user-images.githubusercontent.com/6565058/118381892-b8466680-b5bd-11eb-83e4-cf9a9e7f8d78.png)

