### PR TITLE
Fail deploy when spreadsheets are unavailable

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "yarn run build-data; gatsby build",
+    "build": "yarn run build-data && gatsby build",
     "develop": "gatsby develop",
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",

--- a/processData/downloadAndBuildData/downloadGoogleSheets.js
+++ b/processData/downloadAndBuildData/downloadGoogleSheets.js
@@ -13,17 +13,12 @@ const googleSheetIds = {
 }
 
 const requestSheet = async (id, sheet) => {
-  try {
-    const response = await axios.get(
-      `https://sheets.googleapis.com/v4/spreadsheets/${id}/values/${sheet}?key=${
-        process.env.GOOGLE_API_KEY
-      }`
-    )
-    return response.data.values
-  } catch (e) {
-    console.error(e)
-    return []
-  }
+  const response = await axios.get(
+    `https://sheets.googleapis.com/v4/spreadsheets/${id}/values/${sheet}?key=${
+      process.env.GOOGLE_API_KEY
+    }`
+  )
+  return response.data.values
 }
 
 const loadGoogleSheets = async year => {


### PR DESCRIPTION
This will cause our every-other-day deploys to fail if either of the spreadsheets cannot be found, or if any other error happens while `processData/downloadAndBuildData/index.js` is running. Right now, there's a problem with one of the spreadsheets and `processData/downloadAndBuildData/index.js` has been failing since April 22 but our deploys appear to be successful until you dig deep into the logs.

With this change, we'll be able to see much sooner that there's a problem.